### PR TITLE
added jbuilder to the ruby on rails grammar

### DIFF
--- a/grammars/ruby on rails.cson
+++ b/grammars/ruby on rails.cson
@@ -2,7 +2,8 @@
   'rb'
   'rxml'
   'builder'
-  'Gemfile'
+  'Gemfile',
+  'jbuilder'
 ]
 'foldingStartMarker': '(?x)^\n\t    (\\s*+\n\t        (module|class|def\n\t        |unless|if\n\t        |case\n\t        |begin\n\t        |for|while|until\n\t        |(  "(\\\\.|[^"])*+"          # eat a double quoted string\n\t         | \'(\\\\.|[^\'])*+\'        # eat a single quoted string\n\t         |   [^#"\']                # eat all but comments and strings\n\t         )*\n\t         (                 \\s   (do|begin|case)\n\t         | [-+=&|*/~%^<>~] \\s*+ (if|unless)\n\t         )\n\t        )\\b\n\t        (?! [^;]*+ ; .*? \\bend\\b )\n\t    |(  "(\\\\.|[^"])*+"              # eat a double quoted string\n\t     | \'(\\\\.|[^\'])*+\'            # eat a single quoted string\n\t     |   [^#"\']                    # eat all but comments and strings\n\t     )*\n\t     ( \\{ (?!  [^}]*+ \\} )\n\t     | \\[ (?! [^\\]]*+ \\] )\n\t     )\n\t    ).*$\n\t|   [#] .*? \\(fold\\) \\s*+ $         # Sune’s special marker\n\t'
 'foldingStopMarker': '(?x)\n\t\t(   (^|;) \\s*+ end   \\s*+ ([#].*)? $\n\t\t|   ^     \\s*+ [}\\]] \\s*+ ([#].*)? $\n\t\t|   [#] .*? \\(end\\) \\s*+ $    # Sune’s special marker\n\t\t)'


### PR DESCRIPTION
Wanted to see syntax highlighting for *.json.jbuilder views, so I added it to the ruby on rails grammar.
