### PR TITLE
before_action is just a new syntax for before_filter 

### DIFF
--- a/snippets/language-ruby-on-rails.cson
+++ b/snippets/language-ruby-on-rails.cson
@@ -148,7 +148,7 @@
     'body': 'assert_select \'${1:path}\'${2:, :${3:text} => ${4:\'${5:inner_html}\'}}${6: do\n\t$0\nend}'
   'before_action':
     'prefix': 'ba'
-    'body': 'before_action: '
+    'body': 'before_action :${1:method}${2:${3:, :only => ${4:[:${5:action}, :${6:action}]}}${7:, :except => ${8:[:${9:action}, :${10:action}]}}}'
   'before_create':
     'prefix': 'befc'
     'body': 'before_create '


### PR DESCRIPTION
The command for before filters used to be called before_filter, but the Rails core team decided to rename it to emphasize that the filter takes place before particular controller actions.
