### PR TITLE
Add enum to the highlighted activerecord functions

### DIFF
--- a/grammars/ruby on rails.cson
+++ b/grammars/ruby on rails.cson
@@ -181,7 +181,7 @@
     'name': 'support.function.viewhelpers.rails'
   }
   {
-    'match': '\\b(after_create|after_destroy|after_save|after_update|after_validation|after_validation_on_create|after_validation_on_update|before_create|before_destroy|before_save|before_update|before_validation|before_validation_on_create|before_validation_on_update|composed_of|belongs_to|has_one|has_many|has_and_belongs_to_many|store_accessor|validate|validates|validate_on_create|validates_numericality_of|validate_on_update|validates_acceptance_of|validates_associated|validates_confirmation_of|validates_each|validates_format_of|validates_inclusion_of|validates_exclusion_of|validates_length_of|validates_presence_of|validates_size_of|validates_uniqueness_of|attr_protected|attr_accessible|attr_readonly|accepts_nested_attributes_for|default_scope|scope)\\b'
+    'match': '\\b(after_create|after_destroy|after_save|after_update|after_validation|after_validation_on_create|after_validation_on_update|before_create|before_destroy|before_save|before_update|before_validation|before_validation_on_create|before_validation_on_update|composed_of|belongs_to|has_one|has_many|has_and_belongs_to_many|store_accessor|validate|validates|validate_on_create|validates_numericality_of|validate_on_update|validates_acceptance_of|validates_associated|validates_confirmation_of|validates_each|validates_format_of|validates_inclusion_of|validates_exclusion_of|validates_length_of|validates_presence_of|validates_size_of|validates_uniqueness_of|enum|attr_protected|attr_accessible|attr_readonly|accepts_nested_attributes_for|default_scope|scope)\\b'
     'name': 'support.function.activerecord.rails'
   }
   {


### PR DESCRIPTION
This Pull Request adds the [Rails 4.1 enum](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Enum.html) to the activerecord keywords, because it is not highlighted currently:

![bildschirmfoto 2014-08-18 um 10 12 13](https://cloud.githubusercontent.com/assets/5446019/3949037/6f112c24-26af-11e4-8f52-5070e73ff1e0.png)
