### PR TITLE
Recognize Rails 4.1 routes and delete duplicated expression

### DIFF
--- a/grammars/ruby on rails.cson
+++ b/grammars/ruby on rails.cson
@@ -159,7 +159,7 @@
     ]
   }
   {
-    'begin': '(^\\s*)\\w*::Application.routes.draw|(^\\s*)\\w*::Application.routes.draw|(^\\s*)ActionController::Routing::Routes'
+    'begin': '(^\\s*)\\w*::Application.routes.draw|(^\\s*)ActionController::Routing::Routes|(^\\s*)Rails.application.routes.draw'
     'comment': 'Uses ::Application.routes.draw to determine it is a routes file; includes \'source.ruby\' to avoid infinite recursion'
     'end': '^\\1(?=end)\\b'
     'name': 'meta.rails.routes'


### PR DESCRIPTION
Hey!

This adds recognition for Rails 4.1 routes and removes a duplicated expression.

Have a look please, and let me know.

Thanks!