### PR TITLE
Completes controller's callback list

### DIFF
--- a/grammars/ruby on rails.cson
+++ b/grammars/ruby on rails.cson
@@ -173,7 +173,7 @@
     ]
   }
   {
-    'match': '\\b(before_filter|before_action|skip_before_filter|skip_before_action|prepend_before_filter|after_filter|after_action|skip_after_filter|skip_after_action|prepend_after_filter|around_filter|around_action|prepend_around_filter|filter|filter_parameter_logging|layout|require_dependency|render|render_action|render_text|render_file|render_template|render_nothing|render_component|render_without_layout|rescue_from|url_for|redirect_to|redirect_to_path|redirect_to_url|respond_to|helper|helper_method|head|model|service|observer|serialize|scaffold|verify|hide_action)\\b'
+    'match': '\\b(after_action|after_filter|append_after_action|append_after_filter|append_around_action|append_around_filter|append_before_action|append_before_filter|around_action|around_filter|before_action|before_filter|prepend_after_action|prepend_after_filter|prepend_around_action|prepend_around_filter|prepend_before_action|prepend_before_filter|skip_action_callback|skip_after_action|skip_after_filter|skip_around_action|skip_around_filter|skip_before_action|skip_before_filter|skip_filter|filter|filter_parameter_logging|layout|require_dependency|render|render_action|render_text|render_file|render_template|render_nothing|render_component|render_without_layout|rescue_from|url_for|redirect_to|redirect_to_path|redirect_to_url|respond_to|helper|helper_method|head|model|service|observer|serialize|scaffold|verify|hide_action)\\b'
     'name': 'support.function.actionpack.rails'
   }
   {


### PR DESCRIPTION
Latest list of callbacks retrieved from: http://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html

For completeness, I've added the equivalent _filter methods:

- after_action
- after_filter
- append_after_action
- append_after_filter
- append_around_action
- append_around_filter
- append_before_action
- append_before_filter
- around_action
- around_filter
- before_action
- before_filter
- prepend_after_action
- prepend_after_filter
- prepend_around_action
- prepend_around_filter
- prepend_before_action
- prepend_before_filter
- skip_action_callback
- skip_after_action
- skip_after_filter
- skip_around_action
- skip_around_filter
- skip_before_action
- skip_before_filter
- skip_filter