### PR TITLE
Matches additional form helpers

### DIFF
--- a/grammars/ruby on rails.cson
+++ b/grammars/ruby on rails.cson
@@ -177,7 +177,7 @@
     'name': 'support.function.actionpack.rails'
   }
   {
-    'match': '\\b(check_box|content_for|error_messages_for|form_for|fields_for|file_field|hidden_field|image_submit_tag|label|link_to|password_field|radio_button|submit|text_field|text_area)\\b'
+    'match': '\\b(check_box|content_for|error_messages_for|form_for|fields_for|file_field|hidden_field|image_submit_tag|label|link_to|password_field|radio_button|submit|text_field|text_area|email_field|search_field|telephone_field|date_field|datetime_field|datetime_local_field|month_field|week_field|time_field|url_field|color_field|number_field|range_field)\\b'
     'name': 'support.function.viewhelpers.rails'
   }
   {

--- a/grammars/ruby on rails.cson
+++ b/grammars/ruby on rails.cson
@@ -177,7 +177,7 @@
     'name': 'support.function.actionpack.rails'
   }
   {
-    'match': '\\b(check_box|content_for|error_messages_for|form_for|fields_for|file_field|hidden_field|image_submit_tag|label|link_to|password_field|radio_button|submit|text_field|text_area|email_field|search_field|telephone_field|date_field|datetime_field|datetime_local_field|month_field|week_field|time_field|url_field|color_field|number_field|range_field)\\b'
+    'match': '\\b(check_box|color_field|content_for|date_field|datetime_field|datetime_local_field|email_field|error_messages_for|fields_for|file_field|form_for|hidden_field|image_submit_tag|label|link_to|month_field|number_field|password_field|radio_button|range_field|search_field|submit|telephone_field|text_area|text_field|time_field|url_field|week_field)\\b'
     'name': 'support.function.viewhelpers.rails'
   }
   {


### PR DESCRIPTION
I noticed some of the Rails form helpers were missing from syntax highlighting (e.g. email_field). This PR adds the remaining helpers based on the [Rails Form Helpers guide](http://guides.rubyonrails.org/form_helpers.html#other-helpers-of-interest).

Adds:
- email_field
- search_field
- telephone_field
- date_field
- datetime_field
- datetime_local_field
- month_field
- week_field
- time_field
- url_field
- color_field
- number_field
- range_field