### PR TITLE
Snippets: Rails 5 uses new base class conventions: ApplicationMailer & ApplicationRecord

### DIFF
--- a/grammars/ruby on rails.cson
+++ b/grammars/ruby on rails.cson
@@ -54,8 +54,8 @@
     ]
   }
   {
-    'begin': '(^\\s*)(?=class\\s+(([.a-zA-Z0-9_:]+(\\s*<\\s*ActionMailer::Base))))'
-    'comment': 'Uses lookahead to match classes that inherit from ActionMailer::Base; includes \'source.ruby\' to avoid infinite recursion'
+    'begin': '(^\\s*)(?=class\\s+(([.a-zA-Z0-9_:]+(\\s*<\\s*(ActionMailer::Base|ApplicationMailer)))))'
+    'comment': 'Uses lookahead to match classes that inherit from ActionMailer::Base or ApplicationMailer; includes \'source.ruby\' to avoid infinite recursion'
     'end': '^\\1(?=end)\\b'
     'name': 'meta.rails.mailer'
     'patterns': [
@@ -68,8 +68,8 @@
     ]
   }
   {
-    'begin': '(^\\s*)(?=class\\s+.+ActiveRecord::Base)'
-    'comment': 'Uses lookahead to match classes that (may) inherit from ActiveRecord::Base; includes \'source.ruby\' to avoid infinite recursion'
+    'begin': '(^\\s*)(?=class\\s+.+(ActiveRecord::Base|ApplicationRecord))'
+    'comment': 'Uses lookahead to match classes that (may) inherit from ActiveRecord::Base or ApplicationRecord; includes \'source.ruby\' to avoid infinite recursion'
     'end': '^\\1(?=end)\\b'
     'name': 'meta.rails.model'
     'patterns': [

--- a/spec/snippets-spec.coffee
+++ b/spec/snippets-spec.coffee
@@ -1,0 +1,29 @@
+describe "Ruby on Rails snippets", ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-ruby-on-rails")
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.ruby.rails")
+
+  it "tokenizes ActionMailer::Base", ->
+    railsMailer = 'class RailsMailer < ActionMailer::Base'
+    {tokens} = grammar.tokenizeLine railsMailer
+    expect(tokens[0]).toEqual value: railsMailer, scopes: ['source.ruby.rails', 'meta.rails.mailer']
+
+  it "tokenizes ApplicationMailer", ->
+    rails5Mailer = 'class Rails5Mailer < ApplicationMailer'
+    {tokens} = grammar.tokenizeLine rails5Mailer
+    expect(tokens[0]).toEqual value: rails5Mailer, scopes: ['source.ruby.rails', 'meta.rails.mailer']
+
+  it "tokenizes ActiveRecord::Base", ->
+    railsModel = 'class RailsModel < ActiveRecord::Base'
+    {tokens} = grammar.tokenizeLine railsModel
+    expect(tokens[0]).toEqual value: railsModel, scopes: ['source.ruby.rails', 'meta.rails.model']
+
+  it "tokenizes ApplicationRecord", ->
+    rails5Model = 'class Rails5Model < ApplicationRecord'
+    {tokens} = grammar.tokenizeLine rails5Model
+    expect(tokens[0]).toEqual value: rails5Model, scopes: ['source.ruby.rails', 'meta.rails.model']


### PR DESCRIPTION
Using Rails 5.0.0 beta, I noticed some snippets stopped working. This PR updates the following:

- `meta.rails.model` to alternatively look for the new `ApplicationRecord` convention
- `meta.rails.mailer` to alternatively look for the new `ApplicationMailer` convention