### PR TITLE
Fix embedded-erb in strings

### DIFF
--- a/grammars/html (rails).cson
+++ b/grammars/html (rails).cson
@@ -9,34 +9,49 @@
 'foldingStopMarker': '(?x)\n\t\t(</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)>\n\t\t|^\\s*-->\n\t\t|(^|\\s)\\}\n\t\t)'
 'patterns': [
   {
-    'begin': '<%+#'
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.erb'
-    'end': '%>'
-    'name': 'comment.block.erb'
-  }
-  {
-    'begin': '<%+(?!>)[-=]?'
-    'captures':
-      '0':
-        'name': 'punctuation.section.embedded.ruby'
-    'end': '-?%>'
-    'name': 'source.ruby.rails.embedded.html'
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.comment.ruby'
-        'match': '(#).*?(?=-?%>)'
-        'name': 'comment.line.number-sign.ruby'
-      }
-      {
-        'include': 'source.ruby.rails'
-      }
-    ]
+    'include': '#tags'
   }
   {
     'include': 'text.html.basic'
   }
 ]
+'injections':
+  'string.quoted':
+    'patterns': [
+      {
+        'include': '#tags'
+      }
+    ]
+
+'repository':
+  'tags':
+    'patterns': [
+      {
+        'begin': '<%+#'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.erb'
+        'end': '%>'
+        'name': 'comment.block.erb'
+      }
+      {
+        'begin': '<%+(?!>)[-=]?'
+        'captures':
+          '0':
+            'name': 'punctuation.section.embedded.ruby'
+        'end': '-?%>'
+        'name': 'source.ruby.rails.embedded.html'
+        'patterns': [
+          {
+            'captures':
+              '1':
+                'name': 'punctuation.definition.comment.ruby'
+            'match': '(#).*?(?=-?%>)'
+            'name': 'comment.line.number-sign.ruby'
+          }
+          {
+            'include': 'source.ruby.rails'
+          }
+        ]
+      }
+    ]

--- a/grammars/javascript (rails).cson
+++ b/grammars/javascript (rails).cson
@@ -7,34 +7,50 @@
 'foldingStopMarker': '\\*\\*/|^\\s*\\}'
 'patterns': [
   {
-    'begin': '<%+#'
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.erb'
-    'end': '%>'
-    'name': 'comment.block.erb'
-  }
-  {
-    'begin': '<%+(?!>)[-=]?'
-    'captures':
-      '0':
-        'name': 'punctuation.section.embedded.ruby'
-    'end': '-?%>'
-    'name': 'source.ruby.rails.embedded.html'
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.comment.ruby'
-        'match': '(#).*?(?=-?%>)'
-        'name': 'comment.line.number-sign.ruby'
-      }
-      {
-        'include': 'source.ruby.rails'
-      }
-    ]
+    'include': '#tags'
   }
   {
     'include': 'source.js'
   }
 ]
+
+'injections':
+  'string.quoted':
+    'patterns': [
+      {
+        'include': '#tags'
+      }
+    ]
+
+'repository':
+  'tags':
+    'patterns': [
+      {
+        'begin': '<%+#'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.erb'
+        'end': '%>'
+        'name': 'comment.block.erb'
+      }
+      {
+        'begin': '<%+(?!>)[-=]?'
+        'captures':
+          '0':
+            'name': 'punctuation.section.embedded.ruby'
+        'end': '-?%>'
+        'name': 'source.ruby.rails.embedded.html'
+        'patterns': [
+          {
+            'captures':
+              '1':
+                'name': 'punctuation.definition.comment.ruby'
+            'match': '(#).*?(?=-?%>)'
+            'name': 'comment.line.number-sign.ruby'
+          }
+          {
+            'include': 'source.ruby.rails'
+          }
+        ]
+      }
+    ]


### PR DESCRIPTION
### Requirements
### Description of the Change
Fix erb-embedded in strings like:
```<div class="<%= var_class %>"></div>```
of 
`$('#mydiv').html('<%=  render :partial=>"mypartial" %>')`

### Alternate Designs

### Benefits

### Possible Drawbacks
### Applicable Issues

Issue _Highlight/snippets not working in *.js.erb strings_  #39

