### PR TITLE
Added es6.erb fileType for source.js.rails

### DIFF
--- a/grammars/javascript (rails).cson
+++ b/grammars/javascript (rails).cson
@@ -1,7 +1,8 @@
 'scopeName': 'source.js.rails source.js.jquery'
 'name': 'JavaScript (Rails)'
 'fileTypes': [
-  'js.erb'
+  'js.erb',
+  'es6.erb'
 ]
 'foldingStartMarker': '/\\*\\*|\\{\\s*$'
 'foldingStopMarker': '\\*\\*/|^\\s*\\}'


### PR DESCRIPTION
### Description of the Change

Sprockets 4 beta (finally) adds functionality for compiling ES6 as part of the asset pipeline. Hurray! They've decided that the filename must end in `.es6`, which when combined with `.erb` like `.js.erb` ends up with files like `bestfileever.es6.erb`. Unfortunately, this package doesn't recognize that.  This very tiny PR adds `.es6.erb` to the fileType list so that it selects the file syntax correctly (currently it's guessing HTML).

Here's where Sprockets describes this setup: https://github.com/rails/sprockets/blob/master/UPGRADING.md#es6-support

### Benefits

People who are trying to use modern JavaScript in their Rails files won't have to suffer with HTML syntax or have to manually choose the file type over and over.

### Possible Drawbacks

Sprockets might choose to use some other sane file extension (like `.js.erb` ?!) but we're stuck with it for now. If that happens, this package would still be covering the existing cases.

### Applicable Issues

There was surprisingly no tests for fileType selection for any of the grammars, and I'm unsure how to add them. It worked on my machine® though.
