### PR TITLE
add image_tag to viewhelpers

### DIFF
--- a/grammars/ruby on rails.cson
+++ b/grammars/ruby on rails.cson
@@ -177,7 +177,7 @@
     'name': 'support.function.actionpack.rails'
   }
   {
-    'match': '\\b(check_box|color_field|content_for|date_field|datetime_field|datetime_local_field|email_field|error_messages_for|fields_for|file_field|form_for|hidden_field|image_submit_tag|label|link_to|month_field|number_field|password_field|radio_button|range_field|search_field|submit|telephone_field|text_area|text_field|time_field|url_field|week_field)\\b'
+    'match': '\\b(check_box|color_field|content_for|date_field|datetime_field|datetime_local_field|email_field|error_messages_for|fields_for|file_field|form_for|hidden_field|image_submit_tag|image_tag|label|link_to|month_field|number_field|password_field|radio_button|range_field|search_field|submit|telephone_field|text_area|text_field|time_field|url_field|week_field)\\b'
     'name': 'support.function.viewhelpers.rails'
   }
   {


### PR DESCRIPTION
### Description of the Change

`image_tag` is highlighted as a View Helper. It's an [OG Rails helper](http://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-image_tag). This was first reported on slim-template/language-slim#18.

### Alternate Designs

The helper could remain unhighlighted.

### Benefits

`image_tag` will be signaled in the editor as  a built-in Rails helper and not a custom helper added to the app. 

### Possible Drawbacks

If a Ruby app has its own `image_tag`, is not a Rails app, and the editor has the Atom Ruby on Rails syntax highlighter, `image_tag` will be highlighted as though it's part of a Rails app, even though it is not.

### Applicable Issues

slim-template/language-slim#18