### PR TITLE
Adds es6.erb which works with Sprockets.

### DIFF
--- a/grammars/javascript (rails).cson
+++ b/grammars/javascript (rails).cson
@@ -1,7 +1,8 @@
 'scopeName': 'source.js.rails source.js.jquery'
 'name': 'JavaScript (Rails)'
 'fileTypes': [
-  'js.erb'
+  'js.erb',
+  'es6.erb'
 ]
 'foldingStartMarker': '/\\*\\*|\\{\\s*$'
 'foldingStopMarker': '\\*\\*/|^\\s*\\}'


### PR DESCRIPTION
`.es6.erb` works with both Rails, and Sprockets (directly in things like jekyll-assets.)

### Description of the Change

Adds support for `.es6.erb`

### Benefits

Atom editor no longer confuses `.es6.erb` with HTML.